### PR TITLE
Upstream seestar changes + event listener capability

### DIFF
--- a/src/seestar_messages.erl
+++ b/src/seestar_messages.erl
@@ -135,14 +135,11 @@ decode(?SUPPORTED, Body) ->
 
 decode(?EVENT, Body) ->
     {EventType, Rest} = seestar_types:decode_string(Body),
-    case EventType of
-        ?TOPOLOGY_CHANGE ->
-            decode_topology_change(Rest);
-        ?STATUS_CHANGE ->
-            decode_status_change(Rest);
-        ?SCHEMA_CHANGE ->
-            decode_schema_change(Rest)
-    end;
+    #event{event = case EventType of
+                       ?TOPOLOGY_CHANGE -> decode_topology_change(Rest);
+                       ?STATUS_CHANGE -> decode_status_change(Rest);
+                       ?SCHEMA_CHANGE -> decode_schema_change(Rest)
+                   end};
 
 decode(?RESULT, Body) ->
     {Kind, Rest} = seestar_types:decode_int(Body),

--- a/src/seestar_messages.erl
+++ b/src/seestar_messages.erl
@@ -37,6 +37,10 @@
 %% event.
 -define(EVENT, 16#0C).
 
+-define(TOPOLOGY_CHANGE, <<"TOPOLOGY_CHANGE">>).
+-define(STATUS_CHANGE, <<"STATUS_CHANGE">>).
+-define(SCHEMA_CHANGE, <<"SCHEMA_CHANGE">>).
+
 -type outgoing() :: #startup{}
                   | #credentials{}
                   | #options{}
@@ -128,6 +132,17 @@ decode(?SUPPORTED, Body) ->
     {KVPairs, _} = seestar_types:decode_string_multimap(Body),
     #supported{versions = proplists:get_value(?VERSION, KVPairs),
                compression = proplists:get_value(?COMPRESSION, KVPairs)};
+
+decode(?EVENT, Body) ->
+    {EventType, Rest} = seestar_types:decode_string(Body),
+    case EventType of
+        ?TOPOLOGY_CHANGE ->
+            decode_topology_change(Rest);
+        ?STATUS_CHANGE ->
+            decode_status_change(Rest);
+        ?SCHEMA_CHANGE ->
+            decode_schema_change(Rest)
+    end;
 
 decode(?RESULT, Body) ->
     {Kind, Rest} = seestar_types:decode_int(Body),
@@ -247,6 +262,20 @@ decode_prepared(Body) ->
     {ID, Rest} = seestar_types:decode_short_bytes(Body),
     {Meta, _} = decode_metadata(Rest),
     #prepared{id = ID, metadata = Meta}.
+
+decode_topology_change(Body) ->
+    {Change, Rest} = seestar_types:decode_string(Body),
+    {{Address, Port}, _} = seestar_types:decode_inet(Rest),
+    #topology_change{change = list_to_atom(string:to_lower(binary_to_list(Change))),
+                     ip = Address,
+                     port = Port}.
+
+decode_status_change(Body) ->
+    {Change, Rest} = seestar_types:decode_string(Body),
+    {{Address, Port}, _} = seestar_types:decode_inet(Rest),
+    #status_change{change = list_to_atom(string:to_lower(binary_to_list(Change))),
+                   ip = Address,
+                   port = Port}.
 
 decode_schema_change(Body) ->
     {Change, Rest} = seestar_types:decode_string(Body),

--- a/src/seestar_session.erl
+++ b/src/seestar_session.erl
@@ -344,7 +344,10 @@ process_frames([Frame|Frames], St) ->
 process_frames([], St) ->
     process_backlog(St).
 
-handle_event(_Frame, St) ->
+handle_event(Frame, St) ->
+    Op = seestar_frame:opcode(Frame),
+    Body = seestar_frame:body(Frame),
+    io:format("Whooa. Event! Decoded:\n~p\n", [seestar_messages:decode(Op, Body)]),
     St.
 
 handle_response(Frame, St) ->


### PR DESCRIPTION
Upstream seestar has fixed the issues (building on R16B) that motivated our original fork.
Separately, include my event listener changes. I've got a PR open on the original repo, too, which has details: https://github.com/iamaleksey/seestar/pull/17/
